### PR TITLE
omero-py 5.6.dev9 

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - python =3
   run:
     - future
+    - numpy
+    - pillow
     - python =3
     - zeroc-ice36-python
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "omero-py" %}
-{% set version = "5.6.dev5" %}
+{% set version = "5.6.dev9" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0e8a76983950deb5a9522e009496eb4874ed922fbb920eca0370f51d0b653d2a
+  sha256: 5e5822e8d989a46956dd5c608f4457ef35951dc92b5c553bfafea77fb29fdf06
 
 build:
   noarch: python


### PR DESCRIPTION
Bump version
Tag: `5.6.dev9-0`