### PR TITLE
omero-py 5.6.0

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "omero-py" %}
-{% set version = "5.6.dev9" %}
+{% set version = "5.6.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5e5822e8d989a46956dd5c608f4457ef35951dc92b5c553bfafea77fb29fdf06
+  sha256: e75f53cd59a37db2f58699114a9c8306361732f27d392e5f25dcf267f583e8e7
 
 build:
   noarch: python


### PR DESCRIPTION
omero-py 5.6.0 release

Tag: `5.6.0-0`