### PR TITLE
OMERO.py 5.8.0

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "omero-py" %}
-{% set version = "5.7.1" %}
+{% set version = "5.8.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,25 +7,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: dfbe346bb1a0119632322f5c887d289ddb6db80e7156fdb6a36831de5fd5b1af
+  sha256: 1ae1823caa62110ae5313da9b7ca6846587cbb6dfe7f41802f05b9a54d6991ff
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   script_env:
     - VERSION_SUFFIX
+  entry_points:
+    - omero = omero.main:main
 
 requirements:
   host:
     - pip
     - python =3
   run:
+    - appdirs
     - future
     - numpy
     - pillow
     - python =3
     - pywin32  # [win]
+    - requests
+    - pyyaml
     - zeroc-ice36-python
 
 test:


### PR DESCRIPTION
Closes https://github.com/ome/conda-omero-py/issues/7

Tag: `5.8.0-0`