### PR TITLE
Get rid of noarch

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -13,7 +13,7 @@ build:
   # Can't use noarch because Windows requirements are different
   # If we remove pywin32 from OMERO.py we could switch to noarch
   # noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   script_env:
     - VERSION_SUFFIX

--- a/meta.yaml
+++ b/meta.yaml
@@ -10,7 +10,9 @@ source:
   sha256: c636ee6141d7b64c17f37f13159d5f9672d1050ae7bd482d3909404e5ea1c568
 
 build:
-  noarch: python
+  # Can't use noarch because Windows requirements are different
+  # If we remove pywin32 from OMERO.py we could switch to noarch
+  # noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   script_env:


### PR DESCRIPTION
Since this has OS-specific dependencies it can't be noarch even though the code is cross-platform

Closes https://github.com/ome/conda-omero-py/issues/13