### PR TITLE
Bump version

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "omero-py" %}
-{% set version = "5.8.2" %}
+{% set version = "5.9.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c636ee6141d7b64c17f37f13159d5f9672d1050ae7bd482d3909404e5ea1c568
+  sha256: b53e04394a557675197adea2d6396ea9a0922ac1fa39a3d5c8460e9579a2b462
 
 build:
   # Can't use noarch because Windows requirements are different


### PR DESCRIPTION
* Bump version to 5.9.0
This is be a good candidate for deployment on anaconda
cc @sbesson 