### PR TITLE
Revert "Update conda"

### DIFF
--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -19,7 +19,6 @@ jobs:
         uses: s-weigand/setup-conda@v1.0.7
         with:
           python-version: ${{ matrix.python }}
-          update-conda: true
       - name: Set conda-bld output folder to make it easier to find artifacts
         id: condablddir
         # On Windows /conda-bld and \\conda-bld work here but fail later


### PR DESCRIPTION
This reverts commit baf6294fb3d0d96ef0d11a09de362bda39bcee9e.

Unfortunately, the `update-conda` option seems to cause new issues - see https://github.com/ome/conda-omero-py/runs/4476997656?check_suite_focus=true